### PR TITLE
Share online/offline status to contacts

### DIFF
--- a/api.go
+++ b/api.go
@@ -28,6 +28,9 @@ func ServeWs(hub *Hub, w http.ResponseWriter, r *http.Request) {
 	// Sending messages that were sent to the client when they were offline
 	client.PreviousMessages()
 
+	// This will broadcast that this client is online to all users who have this client as a contact
+	client.ShareStatus()
+
 	// Allow collection of memory referenced by the caller by doing all work in
 	// new goroutines.
 	go client.writePump()

--- a/api.go
+++ b/api.go
@@ -11,7 +11,7 @@ import (
 func ServeWs(hub *Hub, w http.ResponseWriter, r *http.Request) {
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.Println(err)
+		log.Printf("ServeWs upgrader error: %v", err)
 		return
 	}
 

--- a/api.go
+++ b/api.go
@@ -29,7 +29,7 @@ func ServeWs(hub *Hub, w http.ResponseWriter, r *http.Request) {
 	client.PreviousMessages()
 
 	// This will broadcast that this client is online to all users who have this client as a contact
-	client.ShareStatus()
+	client.ShareStatus("online")
 
 	// Allow collection of memory referenced by the caller by doing all work in
 	// new goroutines.

--- a/api.go
+++ b/api.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"encoding/json"
 	"log"
 	"net/http"
 )
@@ -31,4 +32,25 @@ func ServeWs(hub *Hub, w http.ResponseWriter, r *http.Request) {
 	// new goroutines.
 	go client.writePump()
 	go client.readPump()
+}
+
+// SubmitContacts
+func SubmitContacts(currentUser string, w http.ResponseWriter, r *http.Request) {
+	db, err := OpenDb("test.db")
+	if err != nil {
+		log.Printf("Could not open db: %v", err)
+		return
+	}
+
+	decoder := json.NewDecoder(r.Body)
+
+	var contacts []ContactsRequest
+	if err := decoder.Decode(&contacts); err != nil {
+		log.Printf("Error in parsing JSON: %v", err)
+		return
+	}
+
+	addContactsToDB(currentUser, contacts, db)
+
+	w.Write(marshal(contacts))
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -33,5 +33,9 @@ func main() {
 		chat.ServeWs(hub, w, r)
 	})
 
-	http.ListenAndServe(":6446", mux)
+	mux.HandleFunc("/submitContacts", func(w http.ResponseWriter, r *http.Request) {
+		chat.SubmitContacts("0123456789", w, r)
+	})
+
+	log.Fatal(http.ListenAndServe(":6446", mux))
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -33,5 +33,5 @@ func main() {
 		chat.ServeWs(hub, w, r)
 	})
 
-	http.ListenAndServe(":8081", mux)
+	http.ListenAndServe(":6446", mux)
 }

--- a/client.go
+++ b/client.go
@@ -128,7 +128,7 @@ func (c *Client) writePump() {
 			}
 
 			// Always make a message as a list of messages, to be consistent with the database
-			c.conn.WriteJSON(Response{Type: "chat", Message: []Message{*message}})
+			c.conn.WriteJSON(Response{Messages: []Message{*message}})
 
 			// We need to mark this message as read now, because we already sent it to the client
 			// otherwise it will be sent again.
@@ -156,7 +156,7 @@ func (c *Client) PreviousMessages() {
 
 	// This `if` guard is here because we don't want to send `null` when there are no unread messages
 	if len(chats) > 0 {
-		c.conn.WriteJSON(Response{Type: "chat", Message: chats})
+		c.conn.WriteJSON(Response{Messages: chats})
 		updateStatus(c.ID, c.db)
 	}
 }

--- a/client.go
+++ b/client.go
@@ -72,7 +72,7 @@ func (c *Client) readPump() {
 		_, messageJSON, err := c.conn.ReadMessage()
 		if err != nil {
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
-				log.Printf("error: %v", err)
+				log.Printf("readPump error: %v", err)
 			}
 			break
 		}
@@ -82,7 +82,7 @@ func (c *Client) readPump() {
 		var message Message
 		// we also need to capture the sender's ID here...
 		if err := json.Unmarshal(messageJSON, &message); err != nil {
-			log.Printf("error: %v", err)
+			log.Printf("readPump Unmarshal JSON error: %v", err)
 		}
 		message.From = c.ID // sender's ID
 		message.Date = time.Now().Unix()
@@ -150,7 +150,7 @@ func (c *Client) writePump() {
 func (c *Client) PreviousMessages() {
 	chats, err := getUnreadMessages(c.ID, c.db)
 	if err != nil {
-		log.Printf("error: %v", err)
+		log.Printf("getUnreadMessages error: %v", err)
 		return
 	}
 

--- a/client.go
+++ b/client.go
@@ -163,14 +163,14 @@ func (c *Client) PreviousMessages() {
 
 // ShareStatus will send `status` messages to all connected clients that have registered
 // the current client as a contact.
-func (c *Client) ShareStatus() {
+func (c *Client) ShareStatus(status string) {
 	contacts, err := getContacts(c.ID, c.db)
 	if err == nil {
 		log.Printf("Contacts: %v", contacts)
 		for _, contact := range contacts {
 			if client, ok := c.hub.clients[contact]; ok {
 				log.Printf("Client is online: %v", client.ID)
-				client.conn.WriteJSON(Response{Status: c.ID})
+				client.conn.WriteJSON(Response{Status: StatusResponse{Mobile: c.ID, ConnectionStatus: status}})
 			}
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -128,7 +128,7 @@ func (c *Client) writePump() {
 			}
 
 			// Always make a message as a list of messages, to be consistent with the database
-			c.conn.WriteMessage(websocket.TextMessage, []byte(marshal([]Message{*message})))
+			c.conn.WriteJSON(Response{Type: "chat", Message: []Message{*message}})
 
 			// We need to mark this message as read now, because we already sent it to the client
 			// otherwise it will be sent again.
@@ -156,7 +156,7 @@ func (c *Client) PreviousMessages() {
 
 	// This `if` guard is here because we don't want to send `null` when there are no unread messages
 	if len(chats) > 0 {
-		c.conn.WriteMessage(websocket.TextMessage, []byte(marshal(chats)))
+		c.conn.WriteJSON(Response{Type: "chat", Message: chats})
 		updateStatus(c.ID, c.db)
 	}
 }

--- a/client.go
+++ b/client.go
@@ -160,3 +160,18 @@ func (c *Client) PreviousMessages() {
 		updateStatus(c.ID, c.db)
 	}
 }
+
+// ShareStatus will send `status` messages to all connected clients that have registered
+// the current client as a contact.
+func (c *Client) ShareStatus() {
+	contacts, err := getContacts(c.ID, c.db)
+	if err == nil {
+		log.Printf("Contacts: %v", contacts)
+		for _, contact := range contacts {
+			if client, ok := c.hub.clients[contact]; ok {
+				log.Printf("Client is online: %v", client.ID)
+				client.conn.WriteJSON(Response{Status: c.ID})
+			}
+		}
+	}
+}

--- a/db.go
+++ b/db.go
@@ -17,6 +17,11 @@ var stmt = `CREATE TABLE IF NOT EXISTS "chats" (
 	PRIMARY KEY("id")
 );`
 
+var stmtContacts = `CREATE TABLE IF NOT EXISTS "contacts" (
+	"first"	 INTEGER,
+	"second" INTEGER
+);`
+
 // Message represents a table of all chat messages that are stored in
 // ws package.
 // We rely on the consumer of the package to provide us with their own database connection client
@@ -30,6 +35,15 @@ type Message struct {
 	Date        int64  `db:"date" json:"date"`
 }
 
+// Contact type represents a relationship between two clients, the relationship reads:
+// `Second` client is a contact of the `First` client, not vice verca. Because person A can have person B
+// in their contact list, but person B may not have A in their contact list. And we don't want to bother B
+// with notifications that A is connected if they don't have A in their contact list.
+type Contact struct {
+	First  string // First client ID
+	Second string // Second client ID
+}
+
 func OpenDb(name string) (*sqlx.DB, error) {
 	db, err := sqlx.Connect("sqlite3", name)
 	if err != nil {
@@ -37,6 +51,7 @@ func OpenDb(name string) (*sqlx.DB, error) {
 		return nil, err
 	}
 	db.MustExec(stmt)
+	db.MustExec(stmtContacts)
 	return db, nil
 }
 

--- a/db.go
+++ b/db.go
@@ -9,8 +9,8 @@ import (
 
 var stmt = `CREATE TABLE IF NOT EXISTS "chats" (
 	"id"	TEXT,
-	"from"	INTEGER,
-	"to"	INTEGER,
+	"from"	TEXT,
+	"to"	TEXT,
 	"text"	TEXT,
 	"is_delivered"	INTEGER DEFAULT 0,
 	"date"  INTEGER,
@@ -18,8 +18,8 @@ var stmt = `CREATE TABLE IF NOT EXISTS "chats" (
 );`
 
 var stmtContacts = `CREATE TABLE IF NOT EXISTS "contacts" (
-	"first"	 INTEGER,
-	"second" INTEGER
+	"first"	 TEXT,
+	"second" TEXT
 );`
 
 // Message represents a table of all chat messages that are stored in

--- a/db.go
+++ b/db.go
@@ -121,3 +121,14 @@ func addContactsToDB(currentUser string, contacts []ContactsRequest, db *sqlx.DB
 	}
 	return nil
 }
+
+// getContacts returns a list of user IDs (phone numbers) that have the user with the ID `clientID`
+// as their contact
+func getContacts(clientID string, db *sqlx.DB) ([]string, error) {
+	var contacts []string
+	if err := db.Select(&contacts, `SELECT "first" from contacts where "second" = $1`, clientID); err != nil {
+		log.Printf("Error retrieving contacts: %v", err)
+		return nil, err
+	}
+	return contacts, nil
+}

--- a/hub.go
+++ b/hub.go
@@ -43,6 +43,7 @@ func (h *Hub) Run() {
 		case client := <-h.unregister:
 			log.Printf("client ID: %s got disconnected", client.ID)
 			if _, ok := h.clients[client.ID]; ok {
+				client.ShareStatus()
 				delete(h.clients, client.ID)
 				close(client.send)
 			}

--- a/hub.go
+++ b/hub.go
@@ -43,7 +43,7 @@ func (h *Hub) Run() {
 		case client := <-h.unregister:
 			log.Printf("client ID: %s got disconnected", client.ID)
 			if _, ok := h.clients[client.ID]; ok {
-				client.ShareStatus()
+				client.ShareStatus("offline")
 				delete(h.clients, client.ID)
 				close(client.send)
 			}

--- a/types.go
+++ b/types.go
@@ -4,10 +4,17 @@ import (
 	"encoding/json"
 )
 
+// StatusResponse is the response send as part of Response in case we are sending
+// a status (online/offline) message.
+type StatusResponse struct {
+	Mobile           string `json:"mobile,omitempty"`
+	ConnectionStatus string `json:"connection_status,omitempty"`
+}
+
 // Response is the object returned by the api in all cases.
 type Response struct {
 	// Status will be null if we're sending chat messages
-	Status string `json:"status,omitempty"`
+	Status StatusResponse `json:"status,omitempty"`
 
 	// Messages will be null if we're sending status of a user
 	Messages []Message `json:"messages,omitempty"`

--- a/types.go
+++ b/types.go
@@ -6,15 +6,11 @@ import (
 
 // Response is the object returned by the api in all cases.
 type Response struct {
-	// Type is the type of Response, there are mainly 2 types:
-	// 1. "status": which is used in notifying the users that one of their contacts is online.
-	// 2. "chat": which is used in sending regular chat messages.
-	Type string
+	// Status will be null if we're sending chat messages
+	Status string `json:"status,omitempty"`
 
-	// Message is the actual message and it depends on the Type of Response.
-	// 1. In case of "status", its type will be string, and its value will be the ID (phone number) of the client that became online.
-	// 2. In case of "chat", its type is []Message, and its value will be the actual chat messages.
-	Message any
+	// Messages will be null if we're sending status of a user
+	Messages []Message `json:"messages,omitempty"`
 }
 
 type validationError struct {

--- a/types.go
+++ b/types.go
@@ -1,6 +1,8 @@
 package chat
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 // Response is the object returned by the api in all cases.
 type Response struct {
@@ -10,10 +12,9 @@ type Response struct {
 	Type string
 
 	// Message is the actual message and it depends on the Type of Response.
-	// 1. In case of "status", it will be the ID (phone number) of the client that became online.
-	// 2. In case of "chat", it will be an array of Message objects.
-	// In all cases they should be converted to []byte
-	Message []byte
+	// 1. In case of "status", its type will be string, and its value will be the ID (phone number) of the client that became online.
+	// 2. In case of "chat", its type is []Message, and its value will be the actual chat messages.
+	Message any
 }
 
 type validationError struct {

--- a/types.go
+++ b/types.go
@@ -13,6 +13,13 @@ type Response struct {
 	Messages []Message `json:"messages,omitempty"`
 }
 
+type ContactsRequest struct {
+	Name   string `json:"name,omitempty"`
+	Mobile string `json:"mobile,omitempty"`
+}
+
+type User ContactsRequest
+
 type validationError struct {
 	Message string `json:"message,omitempty"`
 	Code    string `json:"code,omitempty"`

--- a/types.go
+++ b/types.go
@@ -2,6 +2,20 @@ package chat
 
 import "encoding/json"
 
+// Response is the object returned by the api in all cases.
+type Response struct {
+	// Type is the type of Response, there are mainly 2 types:
+	// 1. "status": which is used in notifying the users that one of their contacts is online.
+	// 2. "chat": which is used in sending regular chat messages.
+	Type string
+
+	// Message is the actual message and it depends on the Type of Response.
+	// 1. In case of "status", it will be the ID (phone number) of the client that became online.
+	// 2. In case of "chat", it will be an array of Message objects.
+	// In all cases they should be converted to []byte
+	Message []byte
+}
+
 type validationError struct {
 	Message string `json:"message,omitempty"`
 	Code    string `json:"code,omitempty"`


### PR DESCRIPTION
This feature allows users to receive online/offline status of their contacts.

It uses the already existing Web Socket connection to send event-based messages (when some contact connects/disconnects) with the new status of the contacts. This forced us to changed the response type return by the API in all Web Socket messages. It goes as the following:

- We have one JSON object that is send in all Web Socket responses. It looks like this
```json
{
	"status": {"mobile": "0123456789", "connection_status": "online"} 
	"messages": [] // This will contain a list of messages
}
```
- Each one of the fields of this object will be omitted in the case of sending the other (i.e. they cannot be sent together).
- In the case of sending a status, the `messages` field will be omitted and the `status` field will contain the phone number of the client and what is their current connection status (online or offline).
- In the case of sending chat messages, the `status` field will be omitted and the `messages` field will contain a list of the messages that are sent to this client.